### PR TITLE
paradox-filter-upgrades filter sort by package

### DIFF
--- a/paradox-menu.el
+++ b/paradox-menu.el
@@ -464,7 +464,8 @@ fetching the list.")
       (message "No packages have upgrades.")
     (package-show-package-list
      (mapcar #'car paradox--upgradeable-packages))
-    (setq paradox--current-filter "Upgrade")))
+    (setq paradox--current-filter "Upgrade")
+    (paradox-sort-by-package nil)))
 
 (set-keymap-parent paradox-menu-mode-map package-menu-mode-map)
 (defvar paradox--filter-map)


### PR DESCRIPTION
When looking at the filter of possible upgrades, it makes sense to sort the list of packages by package name, to make it easier to select/deselect a few packages from upgrade.